### PR TITLE
(fix) Move installation one less level up

### DIFF
--- a/scripts/development/build-contenta_jsonapi.sh
+++ b/scripts/development/build-contenta_jsonapi.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # Move up 3 levels since we are in contenta_jsonapi/script/development.
-BASE_DIR="$(dirname $(dirname $(dirname $(cd ${0%/*} && pwd))))"
+BASE_DIR="$(dirname $(dirname $(cd ${0%/*} && pwd)))"
+
 COMPOSER="$(which composer)"
 DOCROOT="web"
 


### PR DESCRIPTION
Task: 

* [x] Ready for review
* [x] Ready for merge

Let's assume you are in ~/Projects/contenta_jsonapi and you execute the development script.
This currently installs the project in ~/test_contenta_jsonapi, which is a bit against my intuition. Iz this by design

