### PR TITLE
feat(API): Remove Drupalisms from the API

### DIFF
--- a/config/sync/jsonapi_extras.jsonapi_resource_config.action--action.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.action--action.yml
@@ -1,0 +1,51 @@
+uuid: 24cbcc49-0a7d-4b9c-967f-0a58cd2953c0
+langcode: en
+status: true
+dependencies: {  }
+id: action--action
+disabled: true
+path: action/action
+resourceType: action--action
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.base_field_override--base_field_override.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.base_field_override--base_field_override.yml
@@ -1,0 +1,51 @@
+uuid: 2ed2e71e-8121-4371-a72f-daa8e93d9853
+langcode: en
+status: true
+dependencies: {  }
+id: base_field_override--base_field_override
+disabled: true
+path: base_field_override/base_field_override
+resourceType: base_field_override--base_field_override
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.block--block.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.block--block.yml
@@ -1,0 +1,51 @@
+uuid: 2763f554-cd5d-4c4e-a9df-4cd228f1a8b2
+langcode: en
+status: true
+dependencies: {  }
+id: block--block
+disabled: false
+path: blocks
+resourceType: blocks
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.comment--comment.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.comment--comment.yml
@@ -57,7 +57,7 @@ resourceFields:
     disabled: false
   uid:
     fieldName: uid
-    publicName: author
+    publicName: owner
     enhancer:
       id: ''
     disabled: false
@@ -109,7 +109,7 @@ resourceFields:
     disabled: false
   entity_type:
     fieldName: entity_type
-    publicName: entityType
+    publicName: entityTypeId
     enhancer:
       id: ''
     disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.comment--comment.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.comment--comment.yml
@@ -1,0 +1,135 @@
+uuid: bfaa07af-27ff-48ba-82d0-5bc1cd2ec7d6
+langcode: en
+status: true
+dependencies: {  }
+id: comment--comment
+disabled: false
+path: comments
+resourceType: comments
+resourceFields:
+  cid:
+    fieldName: cid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  comment_type:
+    fieldName: comment_type
+    publicName: commentType
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  pid:
+    fieldName: pid
+    publicName: pid
+    enhancer:
+      id: ''
+    disabled: false
+  entity_id:
+    fieldName: entity_id
+    publicName: referencedInternalId
+    enhancer:
+      id: ''
+    disabled: false
+  subject:
+    fieldName: subject
+    publicName: subject
+    enhancer:
+      id: ''
+    disabled: false
+  uid:
+    fieldName: uid
+    publicName: author
+    enhancer:
+      id: ''
+    disabled: false
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  mail:
+    fieldName: mail
+    publicName: mail
+    enhancer:
+      id: ''
+    disabled: false
+  homepage:
+    fieldName: homepage
+    publicName: homepage
+    enhancer:
+      id: ''
+    disabled: false
+  hostname:
+    fieldName: hostname
+    publicName: hostname
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  thread:
+    fieldName: thread
+    publicName: thread
+    enhancer:
+      id: ''
+    disabled: false
+  entity_type:
+    fieldName: entity_type
+    publicName: entityType
+    enhancer:
+      id: ''
+    disabled: false
+  field_name:
+    fieldName: field_name
+    publicName: fieldName
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  comment_body:
+    fieldName: comment_body
+    publicName: body
+    enhancer:
+      id: nested
+      settings:
+        path: value
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.comment--recipe_review.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.comment--recipe_review.yml
@@ -1,0 +1,135 @@
+uuid: edcfd2b7-3fbe-450b-bfbd-2f0c5ba974c2
+langcode: en
+status: true
+dependencies: {  }
+id: comment--recipe_review
+disabled: false
+path: reviews
+resourceType: reviews
+resourceFields:
+  cid:
+    fieldName: cid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  comment_type:
+    fieldName: comment_type
+    publicName: commentType
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  pid:
+    fieldName: pid
+    publicName: pid
+    enhancer:
+      id: ''
+    disabled: false
+  entity_id:
+    fieldName: entity_id
+    publicName: referencedInternalId
+    enhancer:
+      id: ''
+    disabled: false
+  subject:
+    fieldName: subject
+    publicName: subject
+    enhancer:
+      id: ''
+    disabled: false
+  uid:
+    fieldName: uid
+    publicName: author
+    enhancer:
+      id: ''
+    disabled: false
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  mail:
+    fieldName: mail
+    publicName: mail
+    enhancer:
+      id: ''
+    disabled: false
+  homepage:
+    fieldName: homepage
+    publicName: homepage
+    enhancer:
+      id: ''
+    disabled: false
+  hostname:
+    fieldName: hostname
+    publicName: hostname
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  thread:
+    fieldName: thread
+    publicName: thread
+    enhancer:
+      id: ''
+    disabled: false
+  entity_type:
+    fieldName: entity_type
+    publicName: entityType
+    enhancer:
+      id: ''
+    disabled: false
+  field_name:
+    fieldName: field_name
+    publicName: fieldName
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  comment_body:
+    fieldName: comment_body
+    publicName: body
+    enhancer:
+      id: nested
+      settings:
+        path: value
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.comment--recipe_review.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.comment--recipe_review.yml
@@ -57,7 +57,7 @@ resourceFields:
     disabled: false
   uid:
     fieldName: uid
-    publicName: author
+    publicName: owner
     enhancer:
       id: ''
     disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.comment_type--comment_type.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.comment_type--comment_type.yml
@@ -1,0 +1,51 @@
+uuid: 5d507363-10ee-4077-a52a-6e4b0c1dfde8
+langcode: en
+status: true
+dependencies: {  }
+id: comment_type--comment_type
+disabled: false
+path: commentTypes
+resourceType: commentTypes
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.configurable_language--configurable_language.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.configurable_language--configurable_language.yml
@@ -1,0 +1,57 @@
+uuid: b2badd9d-b4f6-4ee7-8ef3-98c40c232dd2
+langcode: en
+status: true
+dependencies: {  }
+id: configurable_language--configurable_language
+disabled: true
+path: configurable_language/configurable_language
+resourceType: configurable_language--configurable_language
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.date_format--date_format.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.date_format--date_format.yml
@@ -1,0 +1,51 @@
+uuid: 6d93ec02-0ef7-4603-a303-7b692698b0bc
+langcode: en
+status: true
+dependencies: {  }
+id: date_format--date_format
+disabled: true
+path: date_format/date_format
+resourceType: date_format--date_format
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.editor--editor.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.editor--editor.yml
@@ -1,0 +1,45 @@
+uuid: bf10adbf-1d9e-4953-a580-69eedd2cffd2
+langcode: en
+status: true
+dependencies: {  }
+id: editor--editor
+disabled: true
+path: editor/editor
+resourceType: editor--editor
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.entity_browser--entity_browser.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.entity_browser--entity_browser.yml
@@ -1,0 +1,51 @@
+uuid: d4fe238e-51ee-4c66-a5c4-2755bd28aaee
+langcode: en
+status: true
+dependencies: {  }
+id: entity_browser--entity_browser
+disabled: true
+path: entity_browser/entity_browser
+resourceType: entity_browser--entity_browser
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.entity_form_display--entity_form_display.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.entity_form_display--entity_form_display.yml
@@ -1,0 +1,51 @@
+uuid: a5f98153-c56f-43f8-97fb-74c5dfa03abc
+langcode: en
+status: true
+dependencies: {  }
+id: entity_form_display--entity_form_display
+disabled: true
+path: entity_form_display/entity_form_display
+resourceType: entity_form_display--entity_form_display
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.entity_form_mode--entity_form_mode.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.entity_form_mode--entity_form_mode.yml
@@ -1,0 +1,51 @@
+uuid: 5ba83277-8c96-45d8-bda7-97ec30e3e047
+langcode: en
+status: true
+dependencies: {  }
+id: entity_form_mode--entity_form_mode
+disabled: true
+path: entity_form_mode/entity_form_mode
+resourceType: entity_form_mode--entity_form_mode
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.entity_view_display--entity_view_display.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.entity_view_display--entity_view_display.yml
@@ -1,0 +1,51 @@
+uuid: 8bf4d07b-0f21-4f47-bb61-91478ad9eb24
+langcode: en
+status: true
+dependencies: {  }
+id: entity_view_display--entity_view_display
+disabled: true
+path: entity_view_display/entity_view_display
+resourceType: entity_view_display--entity_view_display
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.entity_view_mode--entity_view_mode.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.entity_view_mode--entity_view_mode.yml
@@ -1,0 +1,51 @@
+uuid: 88df8ccf-f625-4f6b-b89d-e6807cb84474
+langcode: en
+status: true
+dependencies: {  }
+id: entity_view_mode--entity_view_mode
+disabled: true
+path: entity_view_mode/entity_view_mode
+resourceType: entity_view_mode--entity_view_mode
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.field_config--field_config.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.field_config--field_config.yml
@@ -1,0 +1,51 @@
+uuid: 9209b0fb-6fcc-4e29-b95e-3959b3667eec
+langcode: en
+status: true
+dependencies: {  }
+id: field_config--field_config
+disabled: true
+path: field_config/field_config
+resourceType: field_config--field_config
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.field_storage_config--field_storage_config.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.field_storage_config--field_storage_config.yml
@@ -1,0 +1,51 @@
+uuid: d4c1f528-c8d9-4f8d-98c6-150c57cd5100
+langcode: en
+status: true
+dependencies: {  }
+id: field_storage_config--field_storage_config
+disabled: true
+path: field_storage_config/field_storage_config
+resourceType: field_storage_config--field_storage_config
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.file--file.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.file--file.yml
@@ -27,7 +27,7 @@ resourceFields:
       id: ''
   uid:
     fieldName: uid
-    publicName: author
+    publicName: owner
     enhancer:
       id: ''
     disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.file--file.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.file--file.yml
@@ -1,0 +1,85 @@
+uuid: 48a1c946-8ebd-46d6-8251-de01684d047b
+langcode: en
+status: true
+dependencies: {  }
+id: file--file
+disabled: false
+path: files
+resourceType: files
+resourceFields:
+  fid:
+    fieldName: fid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  uid:
+    fieldName: uid
+    publicName: author
+    enhancer:
+      id: ''
+    disabled: false
+  filename:
+    fieldName: filename
+    publicName: filename
+    enhancer:
+      id: ''
+    disabled: false
+  uri:
+    fieldName: uri
+    publicName: uri
+    enhancer:
+      id: ''
+    disabled: false
+  filemime:
+    fieldName: filemime
+    publicName: mimetype
+    enhancer:
+      id: ''
+    disabled: false
+  filesize:
+    fieldName: filesize
+    publicName: size
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  url:
+    fieldName: url
+    publicName: url
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.filter_format--filter_format.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.filter_format--filter_format.yml
@@ -1,0 +1,63 @@
+uuid: 6bd7ab70-a11b-4f38-86e0-e18ab6793048
+langcode: en
+status: true
+dependencies: {  }
+id: filter_format--filter_format
+disabled: true
+path: filter_format/filter_format
+resourceType: filter_format--filter_format
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.image_style--image_style.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.image_style--image_style.yml
@@ -1,0 +1,51 @@
+uuid: 4a422561-9847-42ef-b649-fbae018bfc59
+langcode: en
+status: true
+dependencies: {  }
+id: image_style--image_style
+disabled: false
+path: imageStyles
+resourceType: imageStyles
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.jsonapi_resource_config--jsonapi_resource_config.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.jsonapi_resource_config--jsonapi_resource_config.yml
@@ -1,0 +1,51 @@
+uuid: 69828020-a9cf-4757-b877-0685797c7e31
+langcode: en
+status: true
+dependencies: {  }
+id: jsonapi_resource_config--jsonapi_resource_config
+disabled: true
+path: jsonapi_resource_config/jsonapi_resource_config
+resourceType: jsonapi_resource_config--jsonapi_resource_config
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.language_content_settings--language_content_settings.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.language_content_settings--language_content_settings.yml
@@ -1,0 +1,45 @@
+uuid: dee584c9-9f58-461c-a80a-e23630f94d60
+langcode: en
+status: true
+dependencies: {  }
+id: language_content_settings--language_content_settings
+disabled: true
+path: language_content_settings/language_content_settings
+resourceType: language_content_settings--language_content_settings
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.media--image.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.media--image.yml
@@ -51,7 +51,7 @@ resourceFields:
     disabled: false
   uid:
     fieldName: uid
-    publicName: author
+    publicName: owner
     enhancer:
       id: ''
     disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.media--image.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.media--image.yml
@@ -1,0 +1,109 @@
+uuid: 677bcc75-fc4f-42b8-86d1-019c75fc7c7c
+langcode: en
+status: true
+dependencies: {  }
+id: media--image
+disabled: false
+path: images
+resourceType: images
+resourceFields:
+  mid:
+    fieldName: mid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: mediaType
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  thumbnail:
+    fieldName: thumbnail
+    publicName: thumbnail
+    enhancer:
+      id: ''
+    disabled: false
+  uid:
+    fieldName: uid
+    publicName: author
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  field_image:
+    fieldName: field_image
+    publicName: imageFile
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.media_bundle--media_bundle.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.media_bundle--media_bundle.yml
@@ -1,0 +1,51 @@
+uuid: 4f1360eb-b6ad-45a0-b959-25cf208e1743
+langcode: en
+status: true
+dependencies: {  }
+id: media_bundle--media_bundle
+disabled: false
+path: mediaBundles
+resourceType: mediaBundles
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.menu--menu.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.menu--menu.yml
@@ -1,0 +1,51 @@
+uuid: 669d42d0-7a33-45c1-9e5d-f4d426c112f3
+langcode: en
+status: true
+dependencies: {  }
+id: menu--menu
+disabled: false
+path: menus
+resourceType: menus
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.menu_link_content--menu_link_content.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.menu_link_content--menu_link_content.yml
@@ -1,0 +1,109 @@
+uuid: 5ff83e05-e571-4f5e-b955-01f1c7f78c68
+langcode: en
+status: true
+dependencies: {  }
+id: menu_link_content--menu_link_content
+disabled: false
+path: menuLinks
+resourceType: menuLinks
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  title:
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+    disabled: false
+  description:
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: ''
+    disabled: false
+  menu_name:
+    fieldName: menu_name
+    publicName: menuInternalId
+    enhancer:
+      id: ''
+    disabled: false
+  link:
+    fieldName: link
+    publicName: link
+    enhancer:
+      id: nested
+      settings:
+        path: uri
+    disabled: false
+  external:
+    fieldName: external
+    publicName: isExternal
+    enhancer:
+      id: ''
+    disabled: false
+  rediscover:
+    disabled: true
+    fieldName: rediscover
+    publicName: rediscover
+    enhancer:
+      id: ''
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  expanded:
+    fieldName: expanded
+    publicName: isExpanded
+    enhancer:
+      id: ''
+    disabled: false
+  enabled:
+    fieldName: enabled
+    publicName: isEnabled
+    enhancer:
+      id: ''
+    disabled: false
+  parent:
+    fieldName: parent
+    publicName: parentIs
+    enhancer:
+      id: ''
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: changedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--article.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--article.yml
@@ -1,0 +1,153 @@
+uuid: 2cf35e2e-8844-4f71-ab1b-350693c6bf93
+langcode: en
+status: true
+dependencies: {  }
+id: node--article
+disabled: false
+path: articles
+resourceType: articles
+resourceFields:
+  nid:
+    fieldName: nid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    fieldName: type
+    publicName: contentType
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  title:
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+    disabled: false
+  uid:
+    fieldName: uid
+    publicName: author
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  promote:
+    fieldName: promote
+    publicName: isPromoted
+    enhancer:
+      id: ''
+    disabled: false
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  path:
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+    disabled: false
+  body:
+    fieldName: body
+    publicName: body
+    enhancer:
+      id: nested
+      settings:
+        path: value
+    disabled: false
+  comment:
+    fieldName: comment
+    publicName: comment
+    enhancer:
+      id: ''
+    disabled: false
+  field_image:
+    fieldName: field_image
+    publicName: image
+    enhancer:
+      id: ''
+    disabled: false
+  field_recipes:
+    fieldName: field_recipes
+    publicName: recipes
+    enhancer:
+      id: ''
+    disabled: false
+  field_tags:
+    fieldName: field_tags
+    publicName: tags
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--article.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--article.yml
@@ -51,7 +51,7 @@ resourceFields:
     disabled: false
   uid:
     fieldName: uid
-    publicName: author
+    publicName: owner
     enhancer:
       id: ''
     disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--page.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--page.yml
@@ -1,0 +1,129 @@
+uuid: 7ba0b776-313e-4d80-a1b1-8495bf270b23
+langcode: en
+status: true
+dependencies: {  }
+id: node--page
+disabled: false
+path: pages
+resourceType: pages
+resourceFields:
+  nid:
+    fieldName: nid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    fieldName: type
+    publicName: contentType
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  title:
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+    disabled: false
+  uid:
+    fieldName: uid
+    publicName: author
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  promote:
+    fieldName: promote
+    publicName: isPromoted
+    enhancer:
+      id: ''
+    disabled: false
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  path:
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+    disabled: false
+  body:
+    fieldName: body
+    publicName: body
+    enhancer:
+      id: nested
+      settings:
+        path: value
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--page.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--page.yml
@@ -51,7 +51,7 @@ resourceFields:
     disabled: false
   uid:
     fieldName: uid
-    publicName: author
+    publicName: owner
     enhancer:
       id: ''
     disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--recipe.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--recipe.yml
@@ -51,7 +51,7 @@ resourceFields:
     disabled: false
   uid:
     fieldName: uid
-    publicName: author
+    publicName: owner
     enhancer:
       id: ''
     disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node--recipe.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node--recipe.yml
@@ -1,0 +1,183 @@
+uuid: a943b0a6-8417-4724-9280-5fb78bbdb1f3
+langcode: en
+status: true
+dependencies: {  }
+id: node--recipe
+disabled: false
+path: recipes
+resourceType: recipes
+resourceFields:
+  nid:
+    fieldName: nid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    fieldName: type
+    publicName: contentType
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isPublished
+    enhancer:
+      id: ''
+    disabled: false
+  title:
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+    disabled: false
+  uid:
+    fieldName: uid
+    publicName: author
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  promote:
+    fieldName: promote
+    publicName: isPromoted
+    enhancer:
+      id: ''
+    disabled: false
+  sticky:
+    disabled: true
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: true
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: true
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: true
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: true
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  path:
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+    disabled: false
+  field_category:
+    fieldName: field_category
+    publicName: category
+    enhancer:
+      id: ''
+    disabled: false
+  field_difficulty:
+    fieldName: field_difficulty
+    publicName: difficulty
+    enhancer:
+      id: ''
+    disabled: false
+  field_image:
+    fieldName: field_image
+    publicName: image
+    enhancer:
+      id: ''
+    disabled: false
+  field_ingredients:
+    fieldName: field_ingredients
+    publicName: ingredients
+    enhancer:
+      id: ''
+    disabled: false
+  field_number_of_services:
+    fieldName: field_number_of_services
+    publicName: numberOfServices
+    enhancer:
+      id: ''
+    disabled: false
+  field_preparation_time:
+    fieldName: field_preparation_time
+    publicName: preparationTime
+    enhancer:
+      id: ''
+    disabled: false
+  field_recipe_instruction:
+    fieldName: field_recipe_instruction
+    publicName: instructions
+    enhancer:
+      id: nested
+      settings:
+        path: value
+    disabled: false
+  field_recipe_reviews_and_testimo:
+    fieldName: field_recipe_reviews_and_testimo
+    publicName: reviews
+    enhancer:
+      id: ''
+    disabled: false
+  field_tags:
+    fieldName: field_tags
+    publicName: tags
+    enhancer:
+      id: ''
+    disabled: false
+  field_total_time:
+    fieldName: field_total_time
+    publicName: totalTime
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.node_type--node_type.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.node_type--node_type.yml
@@ -1,0 +1,51 @@
+uuid: 7cf06d76-dfce-47fb-81b4-711e84e32dcf
+langcode: en
+status: true
+dependencies: {  }
+id: node_type--node_type
+disabled: false
+path: contentTypes
+resourceType: contentTypes
+resourceFields:
+  id:
+    fieldName: id
+    publicName: machineName
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.oauth2_client--oauth2_client.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.oauth2_client--oauth2_client.yml
@@ -1,0 +1,75 @@
+uuid: 475df688-5444-4825-b4c0-8c38dfadae7e
+langcode: en
+status: true
+dependencies: {  }
+id: oauth2_client--oauth2_client
+disabled: true
+path: oauth2_client/oauth2_client
+resourceType: oauth2_client--oauth2_client
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  owner_id:
+    fieldName: owner_id
+    publicName: owner_id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  secret:
+    fieldName: secret
+    publicName: secret
+    enhancer:
+      id: ''
+    disabled: false
+  confidential:
+    fieldName: confidential
+    publicName: confidential
+    enhancer:
+      id: ''
+    disabled: false
+  roles:
+    fieldName: roles
+    publicName: roles
+    enhancer:
+      id: ''
+    disabled: false
+  description:
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: ''
+    disabled: false
+  image:
+    fieldName: image
+    publicName: image
+    enhancer:
+      id: ''
+    disabled: false
+  redirect:
+    fieldName: redirect
+    publicName: redirect
+    enhancer:
+      id: ''
+    disabled: false
+  user_id:
+    fieldName: user_id
+    publicName: user_id
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.oauth2_token_type--oauth2_token_type.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.oauth2_token_type--oauth2_token_type.yml
@@ -1,0 +1,51 @@
+uuid: 6d59b42a-4f12-46d9-b821-8a38e235ea5f
+langcode: en
+status: true
+dependencies: {  }
+id: oauth2_token_type--oauth2_token_type
+disabled: true
+path: oauth2_token_type/oauth2_token_type
+resourceType: oauth2_token_type--oauth2_token_type
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.rest_resource_config--rest_resource_config.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.rest_resource_config--rest_resource_config.yml
@@ -1,0 +1,45 @@
+uuid: c7112c48-3b79-464e-bb18-dd293d4871c5
+langcode: en
+status: true
+dependencies: {  }
+id: rest_resource_config--rest_resource_config
+disabled: true
+path: rest_resource_config/rest_resource_config
+resourceType: rest_resource_config--rest_resource_config
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--category.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--category.yml
@@ -1,0 +1,79 @@
+uuid: 227ed15d-318c-47ab-8c72-55e6d3ec7e56
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_term--category
+disabled: false
+path: categories
+resourceType: categories
+resourceFields:
+  tid:
+    fieldName: tid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  description:
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: nested
+      settings:
+        path: value
+    disabled: false
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  parent:
+    fieldName: parent
+    publicName: parent
+    enhancer:
+      id: ''
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  path:
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--tags.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_term--tags.yml
@@ -1,0 +1,79 @@
+uuid: d892aa32-09d3-4596-801c-97f3a5f0b5b3
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_term--tags
+disabled: false
+path: tags
+resourceType: tags
+resourceFields:
+  tid:
+    fieldName: tid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  vid:
+    disabled: true
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  description:
+    fieldName: description
+    publicName: description
+    enhancer:
+      id: nested
+      settings:
+        path: value
+    disabled: false
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  parent:
+    fieldName: parent
+    publicName: parent
+    enhancer:
+      id: ''
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  path:
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_vocabulary--taxonomy_vocabulary.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.taxonomy_vocabulary--taxonomy_vocabulary.yml
@@ -1,0 +1,57 @@
+uuid: 48fbc193-2b03-4c98-824b-b8ddc894e6ce
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_vocabulary--taxonomy_vocabulary
+disabled: false
+path: vocabularies
+resourceType: vocabularies
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.user--user.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.user--user.yml
@@ -1,0 +1,117 @@
+uuid: 8c21ae84-b7ff-4614-8311-232244660f32
+langcode: en
+status: true
+dependencies: {  }
+id: user--user
+disabled: false
+path: users
+resourceType: users
+resourceFields:
+  uid:
+    fieldName: uid
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  preferred_langcode:
+    disabled: true
+    fieldName: preferred_langcode
+    publicName: preferred_langcode
+    enhancer:
+      id: ''
+  preferred_admin_langcode:
+    disabled: true
+    fieldName: preferred_admin_langcode
+    publicName: preferred_admin_langcode
+    enhancer:
+      id: ''
+  name:
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+    disabled: false
+  pass:
+    disabled: true
+    fieldName: pass
+    publicName: pass
+    enhancer:
+      id: ''
+  mail:
+    fieldName: mail
+    publicName: mail
+    enhancer:
+      id: ''
+    disabled: false
+  timezone:
+    fieldName: timezone
+    publicName: timezone
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: isActive
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: createdAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: updatedAt
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  access:
+    fieldName: access
+    publicName: access
+    enhancer:
+      id: ''
+    disabled: false
+  login:
+    fieldName: login
+    publicName: lastLogin
+    enhancer:
+      id: date_time
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sO'
+    disabled: false
+  init:
+    disabled: true
+    fieldName: init
+    publicName: init
+    enhancer:
+      id: ''
+  roles:
+    fieldName: roles
+    publicName: roles
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.user_role--user_role.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.user_role--user_role.yml
@@ -1,0 +1,57 @@
+uuid: 8e9cd071-be9b-4ad0-bbcc-b082647fa716
+langcode: en
+status: true
+dependencies: {  }
+id: user_role--user_role
+disabled: false
+path: roles
+resourceType: roles
+resourceFields:
+  id:
+    fieldName: id
+    publicName: internalId
+    enhancer:
+      id: ''
+    disabled: false
+  weight:
+    fieldName: weight
+    publicName: weight
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    disabled: true
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    disabled: true
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: true
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  uuid:
+    disabled: true
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''

--- a/config/sync/jsonapi_extras.jsonapi_resource_config.view--view.yml
+++ b/config/sync/jsonapi_extras.jsonapi_resource_config.view--view.yml
@@ -1,0 +1,57 @@
+uuid: de2e8b8e-540e-43b7-8944-a1f4646212c9
+langcode: en
+status: true
+dependencies: {  }
+id: view--view
+disabled: true
+path: view/view
+resourceType: view--view
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  label:
+    fieldName: label
+    publicName: label
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+    disabled: false
+  revision:
+    fieldName: revision
+    publicName: revision
+    enhancer:
+      id: ''
+    disabled: false
+  bundle:
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false

--- a/config/sync/jsonapi_extras.settings.yml
+++ b/config/sync/jsonapi_extras.settings.yml
@@ -1,1 +1,1 @@
-path_prefix: jsonapi
+path_prefix: api

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -11,3 +11,4 @@ is_admin: false
 permissions:
   - 'access content'
   - 'view media'
+  - 'access jsonapi resource list'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -11,3 +11,4 @@ is_admin: false
 permissions:
   - 'access content'
   - 'view media'
+  - 'access jsonapi resource list'


### PR DESCRIPTION
Task: #23

* [x] Ready for review
* [x] Ready for merge

Removes the Drupalisms from the API so the routes and fields are self explanatory.

### Notes
If you checkout the code in your local, explore the Docson schemas to see the results.

### QA

![inspect schema contenta json api 2017-05-29 22-39-56](https://cloud.githubusercontent.com/assets/1140906/26561578/cd2984e2-44bf-11e7-8530-9b37b64d8a02.png)



