### PR TITLE
Support CORS properly for localhost (on all ports) by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "patches": {
             "drupal/core": {
                 "Allow a profile to be installed from existing config": "https://www.drupal.org/files/issues/2788777-33.patch"
+            },
+            "asm89/stack-cors": {
+              "Add origin matcher for wildcard matching": "https://github.com/asm89/stack-cors/pull/42/files.patch"
             }
         }
     },

--- a/contenta_jsonapi.install
+++ b/contenta_jsonapi.install
@@ -16,7 +16,7 @@ function contenta_jsonapi_install() {
   $yml_data['parameters']['cors.config']['enabled'] = TRUE;
   $yml_data['parameters']['cors.config']['allowedHeaders'] = ['*'];
   $yml_data['parameters']['cors.config']['allowedMethods'] = ['*'];
-  $yml_data['parameters']['cors.config']['allowedOrigins'] = ['localhost:8000', 'localhost:4000', 'localhost:3000'];
+  $yml_data['parameters']['cors.config']['allowedOrigins'] = ['localhost:*'];
 
   file_put_contents($file_path . '/services.yml', Yaml::encode($yml_data));
 }


### PR DESCRIPTION
Task: 

* [x] Ready for review
* [x] Ready for merge

You currently have to still configure CORS given that the asm-89 library doens't support matching on ports.

This PR makes this possible, but then also switch to allow any port.