### PR TITLE
Ensure that both files and media have an author

### DIFF
--- a/modules/recipes_magazin/migrations/recipes_magazin__images_url.yml
+++ b/modules/recipes_magazin/migrations/recipes_magazin__images_url.yml
@@ -14,5 +14,8 @@ process:
     method: row
   filename: image
   uri: image
+  uid:
+    plugin: default_value
+    default_value: 1
 destination:
   plugin: 'entity:file'

--- a/modules/recipes_magazin/migrations/recipes_magazin__media_images_url.yml
+++ b/modules/recipes_magazin/migrations/recipes_magazin__media_images_url.yml
@@ -13,6 +13,9 @@ process:
     migration: recipes_magazin__images_url
     source: image
   name: image
+  uid:
+    plugin: default_value
+    default_value: 1
 destination:
   plugin: 'entity:media'
   default_bundle: image


### PR DESCRIPTION
Task: #

* [x] Ready for review
* [x] Ready for merge

Currently files don't have a UID attached which is sad, as this results into response looking like:

```
"relationships":{"owner":{"data":null}}
```

Depending on the parser, this might break it completely, like the jsonapi one.

### Notes

### Test Instructions

### QA
