### PR TITLE
feat(CORS): Only update CORS if it is disabled

### DIFF
--- a/contenta_jsonapi.install
+++ b/contenta_jsonapi.install
@@ -13,10 +13,12 @@ function contenta_jsonapi_install() {
   $services_yml = file_get_contents($file_path . '/default.services.yml');
 
   $yml_data = Yaml::decode($services_yml);
-  $yml_data['parameters']['cors.config']['enabled'] = TRUE;
-  $yml_data['parameters']['cors.config']['allowedHeaders'] = ['*'];
-  $yml_data['parameters']['cors.config']['allowedMethods'] = ['*'];
-  $yml_data['parameters']['cors.config']['allowedOrigins'] = ['localhost:*'];
+  if (empty($yml_data['parameters']['cors.config']['enabled'])) {
+    $yml_data['parameters']['cors.config']['enabled'] = TRUE;
+    $yml_data['parameters']['cors.config']['allowedHeaders'] = ['*'];
+    $yml_data['parameters']['cors.config']['allowedMethods'] = ['*'];
+    $yml_data['parameters']['cors.config']['allowedOrigins'] = ['localhost:*'];
 
-  file_put_contents($file_path . '/services.yml', Yaml::encode($yml_data));
+    file_put_contents($file_path . '/services.yml', Yaml::encode($yml_data));
+  }
 }


### PR DESCRIPTION
So we can set the CORS settings to `*` during deploy in the demo site (and others).

* [x] Ready for review
* [x] Ready for merge

... description

### Notes

... Notes-optional

### Test Instructions

Test-instructions

### QA

... Screenshots/Screencasts-optional


