### PR TITLE
Added webflo/drupal-core-strict.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "composer/installers": "^1.0",
         "cweagans/composer-patches": "~1.0",
         "drupal/core": "^8.3.0",
+        "webflo/drupal-core-strict": "^8.3.0",
         "drupal/jsonapi": "^1.0",
         "drupal/simple_oauth": "^2.0",
         "drupal/jsonapi_extras": "^1.0",


### PR DESCRIPTION
Task: #64 

* [x] Ready for review
* [x] Ready for merge

This should resolve #64.  Per @webflo's comment on https://github.com/acquia/reservoir/pull/6#issuecomment-310070211 the same version for core and core-strict should be specified to keep them in lock-step to prevent accidental downgrades.

### Notes

... Notes-optional

### Test Instructions

Test-instructions

### QA

... Screenshots/Screencasts-optional


