### PR TITLE
Use https instead of git for downloading the contenta repo

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -2,7 +2,7 @@
 
 original_wd=$(pwd)
 mytmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-git clone --depth=1 git@github.com:contentacms/contenta_jsonapi.git $mytmpdir
+git clone --depth=1 https://github.com/contentacms/contenta_jsonapi.git $mytmpdir
 cd $mytmpdir
 read -n 1 -p "Do you wish to install Contenta CMS (y/n)? " answer
 if echo "$answer" | grep -iq "^y" ;then


### PR DESCRIPTION
Task: 

* [x] Ready for review
* [x] Ready for merge

## Advantages

In case you don't use ssh-agent you need to put in your ssh credentials, http doesn't need authentication
* In some setups git might not be available
