### PR TITLE
Fixed CORS default origins.

### DIFF
--- a/contenta_jsonapi.install
+++ b/contenta_jsonapi.install
@@ -17,7 +17,7 @@ function contenta_jsonapi_install() {
     $yml_data['parameters']['cors.config']['enabled'] = TRUE;
     $yml_data['parameters']['cors.config']['allowedHeaders'] = ['*'];
     $yml_data['parameters']['cors.config']['allowedMethods'] = ['*'];
-    $yml_data['parameters']['cors.config']['allowedOrigins'] = ['localhost:*'];
+    $yml_data['parameters']['cors.config']['allowedOrigins'] = ['localhost','*'];
 
     file_put_contents($file_path . '/services.yml', Yaml::encode($yml_data));
   }


### PR DESCRIPTION
Task: #123

* [x] Ready for review
* [x] Ready for merge

With the install, the services.yml ends up as

```
  cors.config:
    enabled: true
    allowedHeaders:
      - '*'
    allowedMethods:
      - '*'
    allowedOrigins:
      - 'localhost:*'
    exposedHeaders: false
    maxAge: false
    supportsCredentials: false
```

instead of

```
  cors.config:
    enabled: true
    allowedHeaders:
      - '*'
    allowedMethods:
      - '*'
    allowedOrigins:
      - 'localhost'
      - '*'
    exposedHeaders: false
    maxAge: false
    supportsCredentials: false
```

Don't have a test environment set up for testing this yet, so this may need to be tweaked.
