### PR TITLE
Link back to http://contentacms.org

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 # Contenta CMS
 
-Contenta is an API-First Drupal distribution. It's all about the content. Learn more at http://contentacms.org.
+Contenta is an API-First Drupal distribution. It's all about the content. Learn more at [http://contentacms.org](http://contentacms.org).
 
 ## [](#goals)Goals
 One of the conclusions of DrupalCon Baltimore was that Drupal 8 has **impressive tools to build a decoupled application**. However, assembling all the tools together and setting them up correctly can be a little bit daunting. On top of that, once you have everything set up you need to figure out the ins and outs of your front-end project.
 
-With this in mind, Contenta CMS is born to _make your content happy_. Contenta CMS is the response of **the community** to build an API-First Drupal distribution. The goals of Contenta are simple: provide a standard platform that is API ready along with demo content and example front-end applications. In summary, Contenta intends to ease the pain of using, or simply trying, decoupled Drupal.
+With this in mind, Contenta CMS was born to _make your content happy_. Contenta CMS is the response of **the community** to build an API-First Drupal distribution. The goals of Contenta are simple: provide a standard platform that is API ready along with demo content and example front-end applications. In summary, Contenta intends to ease the pain of using, or simply trying, decoupled Drupal.
 
 ## [](#demos)Demos
 An integral part of Contenta is to provide an out of the box content model and demo content ready for you to start working with it. The demo chosen by the community is a [recipe magazine](https://www.drupal.org/node/2818741).


### PR DESCRIPTION
Use markdown formatting so link work on Read the Docs site.

Task: #123

* [x] Ready for review
* [ ] Ready for merge

Read the Docs doesn't parse URLs into links automatically so changing this to a markdown formatted link ensures that the link from http://contentacms.readthedocs.io/en/latest/ back to http://contentacms.org works.