### PR TITLE
 Update Composer file to support Drupal 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "contentacms/contenta_jsonapi",
+    "name": "contentacms/contenta_jsonapi-test",
     "description": "",
     "type": "drupal-profile",
     "authors": [
@@ -15,6 +15,7 @@
 
     ],
     "extra": {
+        "enable-patching": true,
         "installer-paths": {
             "web/core": [
                 "type:drupal-core"
@@ -37,21 +38,20 @@
         },
         "patches": {
             "drupal/core": {
-                "Allow a profile to be installed from existing config": "https://www.drupal.org/files/issues/2788777-33.patch"
+                "Allow a profile to be installed from existing config": "https://www.drupal.org/files/issues/drupal-n2788777-105.patch"
             },
             "drupal/remote_stream_wrapper": {
                 "Module installation fails when shipped as part of an install profile": "https://www.drupal.org/files/issues/2886691-2.patch"
             },
             "asm89/stack-cors": {
-              "Add origin matcher for wildcard matching": "https://patch-diff.githubusercontent.com/raw/asm89/stack-cors/pull/42.patch",
-              "Do not modify request with same origin": "https://github.com/asm89/stack-cors/commit/6daf5757971173b79ddabbd755d59d333c278f42.patch"
+                "(November 29 2017 06:22:06 PM: See issue #223 on contentacms/contenta_jsonapi) Add origin matcher for wildcard matching": "https://raw.githubusercontent.com/cjgratacos/patches/master/asm89_stack-cors/pull_request_42.patch"
             }
         }
     },
     "require": {
-        "composer/installers": "^1.0",
-        "cweagans/composer-patches": "~1.0",
-        "drupal/core": "^8.3.4",
+        "composer/installers": "^1.0.24",
+        "cweagans/composer-patches": "^1.5.0",
+        "drupal/core": "^8.4.2",
         "drupal/jsonapi": "^1.3",
         "drupal/jsonapi_extras": "^1.0@beta",
         "drupal/subrequests": "^2.0@beta",
@@ -72,7 +72,8 @@
         "drupal/decoupled_router": "^1.0@beta"
     },
     "config": {
-      "process-timeout": 0
+      "process-timeout": 0,
+      "preferred-install": "source"
     },
     "scripts": {
         "install-contenta": "scripts/development/build-contenta_jsonapi.sh",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "contentacms/contenta_jsonapi-test",
+    "name": "contentacms/contenta_jsonapi",
     "description": "",
     "type": "drupal-profile",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,6 @@
             },
             "drupal/remote_stream_wrapper": {
                 "Module installation fails when shipped as part of an install profile": "https://www.drupal.org/files/issues/2886691-2.patch"
-            },
-            "asm89/stack-cors": {
-                "(November 29 2017 06:22:06 PM: See issue #223 on contentacms/contenta_jsonapi) Add origin matcher for wildcard matching": "https://raw.githubusercontent.com/cjgratacos/patches/master/asm89_stack-cors/pull_request_42.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
 
     ],
     "extra": {
-        "enable-patching": true,
         "installer-paths": {
             "web/core": [
                 "type:drupal-core"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require": {
         "composer/installers": "^1.0.24",
-        "cweagans/composer-patches": "^1.5.0",
+        "cweagans/composer-patches": "^1.6.0",
         "drupal/core": "^8.4.2",
         "drupal/jsonapi": "^1.3",
         "drupal/jsonapi_extras": "^1.0@beta",


### PR DESCRIPTION
Task: #223 

* [x] Ready for review
* [ ] Reexport configurations
* [ ] Rebase
* [ ] Ready for merge


### Notes

**This PR:**
- depends on https://github.com/contentacms/contenta_jsonapi_project/pull/5.

**Important notes:**
- the patch for asm89/stack-cors had to be moved, please read [here](https://gist.github.com/cjgratacos/bfcb8638b974e44827df0c1bac333ce2) for a more thorough descriptions.