### PR TITLE
Use tagged alpha1 release of material_admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "drupal/dropzonejs": "^1.0@alpha",
         "drupal/schemata": "^1.0@alpha",
         "drupal/openapi": "^1.0@alpha",
-        "drupal/material_admin": "1.x-dev",
+        "drupal/material_admin": "^1.0",
         "drupal/consumers": "^1.0@beta",
         "drupal/consumer_image_styles": "^2.0@rc",
         "drupal/media_entity_browser": "^1.0@beta",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "drupal/dropzonejs": "^1.0@alpha",
         "drupal/schemata": "^1.0@alpha",
         "drupal/openapi": "^1.0@alpha",
-        "drupal/material_admin": "^1.0",
+        "drupal/material_admin": "^1.0@alpha",
         "drupal/consumers": "^1.0@beta",
         "drupal/consumer_image_styles": "^2.0@rc",
         "drupal/media_entity_browser": "^1.0@beta",


### PR DESCRIPTION

* [x] Ready for review
* [x] Ready for merge

A tagged Alpha release of Materia Admin is available now! use that to avoid regressions from dev.

### Test Instructions

Run composer process as normal, ensure that material admin is using Alpha1 release.



