### PR TITLE
feat(jsonrpc): add metadata about the JSON API server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "drupal/inline_entity_form": "^1.0@beta",
         "drupal/jsonapi": "^1.16",
         "drupal/jsonapi_extras": "^2.0",
-        "drupal/jsonrpc": "1.x-dev",
+        "drupal/jsonrpc": "^1.0@alpha",
         "drupal/material_admin": "1.x-dev",
         "drupal/media_entity_browser": "^2.0@alpha",
         "drupal/openapi": "^1.0@alpha",

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -14,3 +14,4 @@ permissions:
   - 'execute graphql requests'
   - 'issue subrequests'
   - 'view media'
+  - 'use jsonrpc services'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -13,3 +13,4 @@ permissions:
   - 'access toolbar'
   - 'issue subrequests'
   - 'view media'
+  - 'use jsonrpc services'

--- a/modules/contenta_enhancements/src/Plugin/jsonrpc/Method/JsonApiMetadata.php
+++ b/modules/contenta_enhancements/src/Plugin/jsonrpc/Method/JsonApiMetadata.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\contenta_enhancements\Plugin\jsonrpc\Method;
+
+use Drupal\Core\Annotation\Translation;
+use Drupal\jsonapi\ResourceType\ResourceTypeRepository;
+use Drupal\jsonrpc\Annotation\JsonRpcMethod;
+use Drupal\jsonrpc\Object\ParameterBag;
+use Drupal\jsonrpc\Plugin\JsonRpcMethodBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Get metadata about JSON API.
+ *
+ * @JsonRpcMethod(
+ *   id = "jsonapi.metadata",
+ *   usage = @Translation("Get metadata about JSON API."),
+ *   access = {"access content"},
+ *   params = {}
+ * )
+ */
+class JsonApiMetadata extends JsonRpcMethodBase {
+
+  /**
+   * The resource type repository.
+   *
+   * @var \Drupal\jsonapi\ResourceType\ResourceTypeRepository
+   */
+  protected $resourceTypeRepository;
+
+  /**
+   * JsonApiMetadata constructor.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ResourceTypeRepository $resource_type_repository) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->resourceTypeRepository = $resource_type_repository;
+  }
+
+  /**
+   * @throws \Drupal\jsonrpc\Exception\JsonRpcException
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $resource_type_repository = $container->get('jsonapi.resource_type.repository');
+    return new static($configuration, $plugin_id, $plugin_definition, $resource_type_repository);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(ParameterBag $params) {
+    // @TODO: Generate the dowloadable URL for the schema on each resource.
+    $schemas = [];
+    return [
+      'prefix' => $this->resourceTypeRepository->getPathPrefix(),
+      'schemas' => $schemas,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function outputSchema() {
+    return [
+      'type' => 'object',
+      'properties' => [
+        'prefix' => ['type' => 'string'],
+        'schemas' => ['type' => 'array', 'items' => ['type' => 'string', 'format' => 'uri']],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Adds an RPC method to obtain information about the JSON API server. This information is used by `contentajs` to know where to forward  the requests.