### PR TITLE
Fix/fix openapi custom callback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "Make the file URLs full URLs": "https://www.drupal.org/files/issues/2929600--use-full-url-file--2.patch"
       },
       "drupal/openapi": {
-        "Small inaccuracies for JSON API schemas": "https://www.drupal.org/files/issues/2018-04-28/2967571--openapi--multiple-minor-adjustments--2.patch"
+        "Small inaccuracies for JSON API schemas": "https://www.drupal.org/files/issues/2018-06-04/openapi-multiple-minor-adjustments-2967571-11.patch"
       },
       "drupal/schemata": {
         "Small inaccuracies for JSON API schemas": "https://www.drupal.org/files/issues/2018-04-28/2967572--schemata--multiple-minor-adjustments--3.patch"

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "drupal/jsonrpc": "^1.0@alpha",
     "drupal/material_admin": "1.x-dev",
     "drupal/media_entity_browser": "^2.0@alpha",
-    "drupal/openapi": "^1.0@alpha",
+    "drupal/openapi": "1.x-dev",
     "drupal/schemata": "^1.0@alpha",
     "drupal/simple_oauth": "^3.3",
     "drupal/subrequests": "^2.0@rc",

--- a/modules/contenta_enhancements/src/Controller/OpenApiDocs.php
+++ b/modules/contenta_enhancements/src/Controller/OpenApiDocs.php
@@ -96,15 +96,13 @@ class OpenApiDocs extends ControllerBase {
         ] + $query,
     ];
 
-    $api_module = 'jsonapi';
-
     $build = [
       '#theme' => 'redoc',
       '#attributes' => [
         'no-auto-auth' => TRUE,
         'scroll-y-offset' => 150,
       ],
-      '#openapi_url' => Url::fromRoute("openapi.download", ['openapi_generator' => $api_module], $route_options)
+      '#openapi_url' => Url::fromRoute('openapi.download', ['openapi_generator' => 'jsonapi'], $route_options)
         ->setAbsolute()
         ->toString(),
     ];

--- a/modules/contenta_enhancements/src/Controller/OpenApiDocs.php
+++ b/modules/contenta_enhancements/src/Controller/OpenApiDocs.php
@@ -95,13 +95,16 @@ class OpenApiDocs extends ControllerBase {
           '_format' => 'json',
         ] + $query,
     ];
+
+    $api_module = 'jsonapi';
+
     $build = [
       '#theme' => 'redoc',
       '#attributes' => [
         'no-auto-auth' => TRUE,
         'scroll-y-offset' => 150,
       ],
-      '#openapi_url' => Url::fromRoute('openapi.jsonapi', [], $route_options)
+      '#openapi_url' => Url::fromRoute("openapi.download", ['openapi_generator' => $api_module], $route_options)
         ->setAbsolute()
         ->toString(),
     ];


### PR DESCRIPTION
Task: #294 

* [x] Ready for review
* [ ] Ready for merge

As noted in the corresponding issue, in order to display the openapi information for json api we need to update to the current dev version of the openapi module. Since the new version has a different route structure, we need to invoke the new route passing the correct parameter in order to get the json schema to be displayed using redoc.

### Notes

My personal doubt here is about including the -dev version in composer.json: since composer.lock is added to .gitignore, isn't there a risk of things breaking when the openapi module get updated in the future?

### Test Instructions

Visit /admin/api to see redoc at work



