### PR TITLE
_contenta_jsonapi_enable_cors() requires Drupal\Component\Serialization\Yaml

### DIFF
--- a/contenta_jsonapi.profile
+++ b/contenta_jsonapi.profile
@@ -7,6 +7,7 @@
 
 use Drupal\contenta_jsonapi\Plugin\Contenta\OptionalModule\AbstractOptionalModule;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Serialization\Yaml;
 
 /**
  * Implements hook_form_FORM_ID_alter() for install_configure_form().


### PR DESCRIPTION
Task: #123

* [x] Ready for review
* [ ] Ready for merge

When trying to install via the UI installer I get an error about a missing `Yaml` class during the "Enable CORs by default" step.

```
Error
The website encountered an unexpected error. Please try again later.
Error: Class 'Yaml' not found in _contenta_jsonapi_enable_cors() (line 141 of profiles/contrib/contenta_jsonapi/contenta_jsonapi.profile).

_contenta_jsonapi_enable_cors(Array) (Line: 709)
install_run_task(Array, Array) (Line: 584)
install_run_tasks(Array, NULL) (Line: 125)
install_drupal(Object) (Line: 44)
```

![error contenta json api 2018-08-07 10-39-38](https://user-images.githubusercontent.com/17613/43787232-2776ed56-9a30-11e8-8ccf-ff192032caf3.png)

This can be fixed by adding `use Drupal\Component\Serialization\Yaml;` to contenta_jsonapi.profile

### Test Instructions

- Run the UI installer and confirm that you don't get stuck on the "Enable CORS by default" step


