### PR TITLE
Add a patch to prevent getIncludes() error with jsonapi 1.23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "Improve path method descriptions": "https://www.drupal.org/files/issues/2018-09-29/3001993--initial-description--7.patch"
       },
       "drupal/jsonapi": {
-        "Only serialize sparse_fieldset fields": "https://www.drupal.org/files/issues/2018-11-05/3011099-12-8.x-1.x.patch"
+        "Only serialize sparse_fieldset fields": "https://www.drupal.org/files/issues/2018-11-05/3011099-12-8.x-1.x.patch",
+        "Error: Call to a member function getIncludes() on null": "https://www.drupal.org/files/issues/2018-11-07/getIncludes-on-null-error-3011836-2.patch"
       }
     }
   },


### PR DESCRIPTION
* [x] Ready for review
* [x] Ready for merge

Add patch to fix jsonapi 1.23 Error when using `?include`.
See [Drupal issue](https://www.drupal.org/project/jsonapi/issues/3011836)

### Test Instructions

Sample of request failing from a fresh ContentaCMS + [contenta_vue_nuxt](https://github.com/contentacms/contenta_vue_nuxt) install:

`api/recipes?include=image,image.thumbnail&fields[images]=thumbnail`
