### PR TITLE
Config change to reflect entity action plugins

### DIFF
--- a/config/sync/system.action.node_delete_action.yml
+++ b/config/sync/system.action.node_delete_action.yml
@@ -6,5 +6,5 @@ dependencies:
 id: node_delete_action
 label: 'Delete content'
 type: node
-plugin: node_delete_action
+plugin: 'entity:delete_action:node'
 configuration: {  }


### PR DESCRIPTION
New (generic/derived) plugins were added in the course of 8.6 development (see https://www.drupal.org/project/drupal/issues/2670730, CR https://www.drupal.org/node/2934349). The update hooks don't seem to have caught this necessary configuration change.

On an existing site running `drush cedit system.action.node_delete_action` (and exporting this change) or changing the configuration in `config/sync/system.action.node_delete_action.yml`

Task: #354

* [x] Ready for review
* [x] Ready for merge

### Test Instructions

Go to `admin/content` select a node, select `Delete` in the bulk actions. Instead of being redirected to the (new and generic) multiple entity deletion confirmation screen, you just see a success message that the (old) action (as ids are only stored in the tempstore but not redirect to the confirmation form is triggered).

After applying the patch/PR, you get redirected to the confirmation screen and - after confirming the deletion - the nodes get deleted, too.

If needed I am happy to provide a contenta-specific update hook. 
