### PR TITLE
Issue 362

### DIFF
--- a/contenta_jsonapi.profile
+++ b/contenta_jsonapi.profile
@@ -92,8 +92,8 @@ function _contenta_jsonapi_generate_keys() {
 function contenta_jsonapi_module_install(array &$install_state) {
   set_time_limit(0);
 
-  $extensions = $install_state['contenta_jsonapi_additional_modules'];
-  $form_values = $install_state['form_state_values'];
+  $extensions = $install_state['forms']['contenta_jsonapi_additional_modules'];
+  $form_values = $install_state['forms']['form_state_values'];
 
   $optional_modules_manager = \Drupal::service('plugin.manager.contenta_jsonapi.optional_modules');
   $definitions = array_map(function ($extension_name) use ($optional_modules_manager) {

--- a/src/Installer/Form/ModuleConfigureForm.php
+++ b/src/Installer/Form/ModuleConfigureForm.php
@@ -117,12 +117,8 @@ class ModuleConfigureForm extends ConfigFormBase {
     }
 
     // Iterate over the form state values to determine modules to install
-    // TODO: can this be stripped in favor of using form_state_values keys?
     foreach ($install_state['form_state_values'] as $key => $value) {
       // Only operate on any values that have `install_modules_`
-      // TODO: small optimization: create default array that contains
-      // the list of of `install_modules_MODULE` with meta information
-      // and iterate over that rather than string searching
       if (strpos($key, 'install_modules_') !== false && $value) {
         // Add module to the additional list
         $install_state['contenta_jsonapi_additional_modules'][] =

--- a/src/Installer/Form/ModuleConfigureForm.php
+++ b/src/Installer/Form/ModuleConfigureForm.php
@@ -54,7 +54,6 @@ class ModuleConfigureForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
-
     return [];
   }
 
@@ -116,12 +115,12 @@ class ModuleConfigureForm extends ConfigFormBase {
 
     $build_info = $form_state->getBuildInfo();
 
-    $install_state = $build_info['args'];
+    $install_state = $build_info['forms'];
 
-    $install_state[0]['contenta_jsonapi_additional_modules'] = $install_modules;
-    $install_state[0]['form_state_values'] = $form_state->getValues();
+    $install_state['contenta_jsonapi_additional_modules'] = $install_modules;
+    $install_state['form_state_values'] = $form_state->getValues();
 
-    $build_info['args'] = $install_state;
+    $build_info['forms'] = $install_state;
 
     $form_state->setBuildInfo($build_info);
   }


### PR DESCRIPTION
Fix Issue #362 

* [x] Ready for review
* [x] Ready for merge

Updates the install script and module configure form to allow for drush site install overrides

### Notes

Committed some TODOs and then removed them for note taking purposes.

### Test Instructions

Tested both GUI install and with the following commands:

```bash
drush site:install --db-url=mysql://drupal8:drupal8@database/drupal8 \ 
--verbose \                                                                                                
--yes
```

``` bash
drush site:install contenta_jsonapi \                                                                                                                                  
form_state_values.install_modules_recipes_magazin=0 \
form_state_values.install_modules_contentajs=1 \
--db-url=mysql://drupal8:drupal8@database/drupal8 \
--verbose \
--yes
```

```bash
drush site:install contenta_jsonapi \
form_state_values.install_modules_recipes_magazin=0 \
--db-url=mysql://drupal8:drupal8@database/drupal8 \
--verbose \
--yes 
```


