### PR TITLE
feat: use the latest major version of Simple OAuth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "drupal/material_admin": "^1.0@alpha",
     "drupal/openapi": "^1.0@beta",
     "drupal/schemata": "^1.0@alpha",
-    "drupal/simple_oauth": "^3.3",
+    "drupal/simple_oauth": "^4.0",
     "drupal/subrequests": "^2.0",
     "drupal/video_embed_field": "^2.0",
     "drupal/openapi_ui": "^1.0@rc",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -46,7 +46,6 @@ module:
   schemata_json_schema: 0
   serialization: 0
   simple_oauth: 0
-  simple_oauth_extras: 0
   subrequests: 0
   syslog: 0
   system: 0


### PR DESCRIPTION
Version `8.x-4.x` deprecates the _Simple OAuth Extras_ module. That functionality is now in _Simple OAuth_.