### PR TITLE
The module simple_oauth_extras is merged into simple_oauth since 4.0

### DIFF
--- a/config/sync/simple_oauth_extras.settings.yml
+++ b/config/sync/simple_oauth_extras.settings.yml
@@ -1,1 +1,0 @@
-use_implicit: true


### PR DESCRIPTION
Task: #123

* [x] Ready for review
* [ ] Ready for merge

Removing this config was missed in commit 11f9a8b39a6022f07ed00f79fdc76d978cc56320 where `drupal/simple_oauth` was updated to 4.0


