### PR TITLE
[#389] Add media.settings.yml to config folder

### DIFF
--- a/config/sync/media.settings.yml
+++ b/config/sync/media.settings.yml
@@ -1,0 +1,4 @@
+icon_base_uri: 'public://media-icons/generic'
+iframe_domain: ''
+oembed_providers_url: 'https://oembed.com/providers.json'
+standalone_url: false


### PR DESCRIPTION
Fix for the issue https://github.com/contentacms/contenta_jsonapi/issues/389

* [x] Ready for review
* [ ] Ready for merge

#### Notes
Missing media.settings.yml cause an error during the installation of Video Embed Media module.

#### Test Instruction
Before the application of PR
1. Install ContentaCMS with `composer run-script install:with-mysql`
2. Go To Extend -> Install New Module and install **Video Embed Media**
Output: An error is returned during the installation

After the application of PR Step 2 is completed successfully without error
