### PR TITLE
fix: 398 upstream - avoid optional modules installed by default

### DIFF
--- a/src/Plugin/Contenta/OptionalModule/ContentaJs.php
+++ b/src/Plugin/Contenta/OptionalModule/ContentaJs.php
@@ -12,7 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   label = @Translation("Contenta JS"),
  *   description = @Translation("Provides server side configuration options for Contenta JS. If you use Contenta JS you will need this module."),
  *   type = "module",
- *   standardlyEnabled = true,
+ *   standardlyEnabled = false,
  * )
  */
 class ContentaJs extends AbstractOptionalModule {

--- a/src/Plugin/Contenta/OptionalModule/RecipesMagazin.php
+++ b/src/Plugin/Contenta/OptionalModule/RecipesMagazin.php
@@ -13,7 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   description = @Translation("The Recipes Magazine module adds a content model and default content for the Umami demo."),
  *   type = "module",
  *   weight = 10,
- *   standardlyEnabled = true,
+ *   standardlyEnabled = false,
  * )
  */
 class RecipesMagazin extends AbstractOptionalModule {


### PR DESCRIPTION
Fix: #398

* [x] Ready for review
* [x] Ready for merge

contentajs and recipe_magazin modules as 'marked' as optional, but it is installed always, even when it shouldn't. In the #398 some example.
