### PR TITLE
Replace drupal_set_message() to \Drupal::messenger()->addMessage()

### DIFF
--- a/modules/contenta_enhancements/contenta_enhancements.module
+++ b/modules/contenta_enhancements/contenta_enhancements.module
@@ -434,7 +434,7 @@ function contenta_enhancements_form_alter(&$form, FormStateInterface $form_state
     $form['roles']['widget']['#description'] .= '<br>' . $recommendation_text;
 
     if ($form_id === 'consumer_add_form' && empty($form['roles']['widget']['#options'])) {
-      drupal_set_message($recommendation_text, 'error');
+      \Drupal::messenger()->addMessage($recommendation_text, 'error');
       $form['actions']['#disabled'] = TRUE;
     }
   }

--- a/modules/contenta_enhancements/src/Form/RevertForm.php
+++ b/modules/contenta_enhancements/src/Form/RevertForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Extension\ThemeInstallerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -23,16 +24,23 @@ class RevertForm extends ConfirmFormBase {
   protected $siteConfig;
 
   /**
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * RevertForm constructor.
    *
    * @param \Drupal\Core\Extension\ModuleInstallerInterface $module_installer
    * @param \Drupal\Core\Extension\ModuleInstallerInterface $module_installer
    * @param \Drupal\Core\Config\Config $theme_config
    * @param \Drupal\Core\Config\Config $site_config
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    */
-  public function __construct(ModuleInstallerInterface $module_installer, Config $site_config) {
+  public function __construct(ModuleInstallerInterface $module_installer, Config $site_config, MessengerInterface $messenger) {
     $this->moduleInstaller = $module_installer;
     $this->siteConfig = $site_config;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -41,7 +49,8 @@ class RevertForm extends ConfirmFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('module_installer'),
-      $container->get('config.factory')->getEditable('system.site')
+      $container->get('config.factory')->getEditable('system.site'),
+      $container->get('messenger')
     );
   }
 
@@ -60,7 +69,7 @@ class RevertForm extends ConfirmFormBase {
     $this->siteConfig->set('page.front', '/admin/content');
     $this->siteConfig->save();
     $this->moduleInstaller->uninstall(['recipes_magazin']);
-    drupal_set_message($this->t('Contenta has successfully reverted to a clean state!'));
+    $this->messenger->addMessage($this->t('Contenta has successfully reverted to a clean state!'));
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 


### PR DESCRIPTION
Task: #123

* [x] Ready for review
* [x] Ready for merge

Replaces the Drupal 8 deprecated drupal_set_message() to \Drupal::messenger->addMessage().

### Test Instructions

Access admin/contenta/revert and submit the form. A message saying "Contenta has successfully reverted to a clean state!" sould appear if no error is thrown.

### QA


