### PR TITLE
Drupal 9.4 mysql module Error - import breaks

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -35,6 +35,7 @@ module:
   media_library: 0
   menu_ui: 0
   migrate: 0
+  mysql: 0
   node: 0
   openapi: 0
   openapi_jsonapi: 0


### PR DESCRIPTION
I am getting errors when updating to drupal 9.4 regarding the MYSQL module and the reason is that Core-provided database drivers moved to their own modules in drupal 9.4. The solution I found is MySQL module should be included in core.extension,yml file. (mysql: 0)

