### PR TITLE
Change (drupal_get_path) deprecated function in recipes_magazin.module

### DIFF
--- a/modules/recipes_magazin/recipes_magazin.module
+++ b/modules/recipes_magazin/recipes_magazin.module
@@ -9,7 +9,7 @@
  * Implements hook_theme_registry_alter().
  */
 function recipes_magazin_theme_registry_alter(&$theme_registry) {
-  $theme_registry['views_view_grid']['path'] = drupal_get_path('module', 'recipes_magazin') . '/templates';
+  $theme_registry['views_view_grid']['path'] = \Drupal::service('extension.list.module')->getPath('recipes_magazin') . '/templates';
 }
 
 /**


### PR DESCRIPTION
[Drupal 10 support]  https://github.com/contentacms/contenta_jsonapi/issues/421

* [x] Ready for review
* [x] Ready for merge

Change **drupal_get_path** deprecated function to become compatible with Drupal 10.

### Notes

> Call to deprecated function drupal_get_path(). Deprecated in drupal:9.3.0 and is removed from drupal:10.0.0. Use Drupal\Core\Extension\ExtensionPathResolver::getPath() instead.



