### PR TITLE
Adding accessCheck method in Drupal queries.

### DIFF
--- a/modules/recipes_magazin/tests/src/Functional/ReinstallationMinimalTest.php
+++ b/modules/recipes_magazin/tests/src/Functional/ReinstallationMinimalTest.php
@@ -26,12 +26,14 @@ class ReinstallationMinimalTest extends BrowserTestBase {
     // there.
     $this->assertArrayHasKey('recipe', \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple());
     $count = \Drupal::entityTypeManager()->getStorage('node')->getQuery()
+      ->accessCheck()
       ->condition('type', 'recipe')
       ->count()
       ->execute();
     $this->assertGreaterThan(0, $count);
 
     $count = \Drupal::entityTypeManager()->getStorage('node')->getQuery()
+      ->accessCheck()
       ->condition('type', 'article')
       ->count()
       ->execute();
@@ -48,6 +50,7 @@ class ReinstallationMinimalTest extends BrowserTestBase {
     // there.
     $this->assertArrayHasKey('recipe', \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple());
     $count = \Drupal::entityTypeManager()->getStorage('node')->getQuery()
+      ->accessCheck()
       ->condition('type', 'recipe')
       ->count()
       ->execute();


### PR DESCRIPTION
[Drupal 10 support] https://github.com/contentacms/contenta_jsonapi/issues/421

Task: https://github.com/contentacms/contenta_jsonapi/issues/421

* [x] Ready for review
* [x] Ready for merge

Fix queries to adding check access it will be removed in Drupal 10

### Notes

> Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.




