### PR TITLE
Adding support for Drupal 10 in recipes_magazin module

### DIFF
--- a/modules/recipes_magazin/recipes_magazin.info.yml
+++ b/modules/recipes_magazin/recipes_magazin.info.yml
@@ -2,7 +2,7 @@ name: Recipes Magazin
 description: Create the content model and default content for a food magazine application.
 type: module
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - comment
   - field


### PR DESCRIPTION
Task: https://github.com/contentacms/contenta_jsonapi/issues/421

* [x] Ready for review
* [x] Ready for merge

Since there is no deprecated function inside this module, it would be changing to support Drupal 10.

There is a soft dependency of this PR https://github.com/contentacms/contenta_jsonapi/pull/423 to fix functional tests inside this module.

### Notes

> Value of core_version_requirement: ^8 || ^9 is not compatible with the next major version of Drupal core. See https://drupal.org/node/3070687.

